### PR TITLE
chore(stylelint-config): add bugs metadata

### DIFF
--- a/packages/config-stylelint/package.json
+++ b/packages/config-stylelint/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/cloud-ru-tech/frontend-tools.git",
     "directory": "packages/config-stylelint"
   },
+  "bugs": {
+    "url": "https://github.com/cloud-ru-tech/frontend-tools/issues"
+  },
   "dependencies": {
     "stylelint": "16.6.1",
     "stylelint-config-recommended-scss": "14.1.0"


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `@cloud-ru/ft-config-stylelint`
- point bug reports to the repository issue tracker
- leave runtime code, dependencies, generated files, version fields, package files, and entry points unchanged

## Verification
- `node - <<'NODE' ...` package metadata assertion for `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` in `packages/config-stylelint`
- `git diff --check`