### PR TITLE
chore: add stylelint config bugs metadata

### DIFF
--- a/packages/config-stylelint/package.json
+++ b/packages/config-stylelint/package.json
@@ -19,6 +19,9 @@
     "LICENSE"
   ],
   "homepage": "https://github.com/cloud-ru-tech/frontend-tools/tree/master/packages/config-stylelint",
+  "bugs": {
+    "url": "https://github.com/cloud-ru-tech/frontend-tools/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/cloud-ru-tech/frontend-tools.git",


### PR DESCRIPTION
## Summary

- add `bugs.url` metadata for `@cloud-ru/ft-config-stylelint`
- point the issue tracker link at this repository's GitHub issues

## Validation

- `node -e "const p=require('./packages/config-stylelint/package.json'); if(p.name!=='@cloud-ru/ft-config-stylelint'||p.homepage!=='https://github.com/cloud-ru-tech/frontend-tools/tree/master/packages/config-stylelint'||p.bugs?.url!=='https://github.com/cloud-ru-tech/frontend-tools/issues'||p.repository?.directory!=='packages/config-stylelint') process.exit(1); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage,bugs:p.bugs,repository:p.repository,license:p.license}, null, 2))"`
- `npm pack --dry-run --ignore-scripts --json --workspace @cloud-ru/ft-config-stylelint`
- `npm install --ignore-scripts`
- `node --input-type=module -e "import config from './packages/config-stylelint/src/index.js'; console.log(Array.isArray(config) ? {type:'array', length:config.length} : {type:typeof config, keys:Object.keys(config).slice(0,10)})"`
- `npm run build:packages:esm`
- `git diff --check`

Note: `npm run test:unit -- --run` currently fails while loading the existing Vitest config because `@cloud-ru/ft-config-vitest` is ESM-only but is being loaded via `require`. This PR only changes package metadata.
